### PR TITLE
fix: ajeita formatação de strings das rotas students

### DIFF
--- a/src/services/api/urls.py
+++ b/src/services/api/urls.py
@@ -18,7 +18,7 @@ urlpatterns = [
     path('admin/logout', AdminLogoutView.as_view(), name='admin-logout'),
     path('gifts', ListRetrieveGiftsView.as_view(), name='list-retrieve-gifts'),
 
-    path('student', include('students.urls')),
+    path('student/', include('students.urls')),
     # Admin endpoints
     path('admin', views.admin_index, name='admin-login-test'),
     path('admin/talks', AdminListCreateTalksView.as_view(), name='admin-list-create-talks'),
@@ -34,8 +34,8 @@ urlpatterns = [
     path('admin/winners', AdminListWinnerView.as_view(), name='admin-list-draw-winners'),
     path('admin/winners/<uuid:student_id>', AdminDestroyWinnerView.as_view(), name='admin-destroy-winner'),
 
-    path('admin/students', include(admin_students_urls)),
-    path('admin/student', include(admin_student_urls)),
+    path('admin/students/', include(admin_students_urls)),
+    path('admin/student/', include(admin_student_urls)),
 
     # path('admin/attendance-report', AdminAttendanceReportView.as_view(), name='admin-attendance-report'),
     # TODO: fazer tudo relacionado aos brindes

--- a/src/services/students/urls.py
+++ b/src/services/students/urls.py
@@ -10,13 +10,13 @@ student_urls = [
 ]
 
 admin_students_urls = [
-    path('admin/students', views.AdminListStudentsView.as_view(), name='admin-list-students'),
-    path('admin/students/search/<name>', views.AdminListStudentsByNameView.as_view(), name='admin-list-students-by-name'),
-    path('admin/students/<student_document>', views.AdminDestroyStudentView.as_view(), name='admin-destroy-student'),
+    path('', views.AdminListStudentsView.as_view(), name='admin-list-students'),
+    path('search/<name>', views.AdminListStudentsByNameView.as_view(), name='admin-list-students-by-name'),
+    path('<student_document>', views.AdminDestroyStudentView.as_view(), name='admin-destroy-student'),
 ]
 
 admin_student_urls = [
-    path('admin/student/<student_document>', views.AdminRetrieveStudentInfoView.as_view(), name='admin-retrieve-student-info'),
+    path('<student_document>', views.AdminRetrieveStudentInfoView.as_view(), name='admin-retrieve-student-info'),
 ]
 
 urlpatterns = student_urls


### PR DESCRIPTION
Os paths estavam sendo concatenados ao invés de separados por um '/'.