### PR TITLE
feat: criar view AdminListCreateWinner #85

### DIFF
--- a/src/services/api/serializers.py
+++ b/src/services/api/serializers.py
@@ -101,6 +101,17 @@ class GiftSerializer(serializers.ModelSerializer):
         )
         return gift
 
+class DrawWinnerSerializer(serializers.ModelSerializer):
+    student = serializers.PrimaryKeyRelatedField(queryset=Student.objects.all())
+    talk = serializers.PrimaryKeyRelatedField(read_only=True)
+
+    class Meta:
+        model = DrawWinner
+        fields = ['id', 'talk', 'student']
+
+    def create(self, validated_data):
+        draw_winner = DrawWinner.objects.create(**validated_data)
+        return draw_winner
 
 class AdminSerializer(serializers.Serializer):
     username = serializers.CharField(required=True)

--- a/src/services/api/urls.py
+++ b/src/services/api/urls.py
@@ -32,7 +32,7 @@ urlpatterns = [
     path('admin/gifts', AdminListCreateGiftsView.as_view(), name='admin-list-create-gifts'),
     path('admin/gifts/<uuid:id>', AdminUpdateDestroyGiftView.as_view(), name='admin-update-destroy-gift'),
     path('admin/winners', AdminListWinnerView.as_view(), name='admin-list-draw-winners'),
-    path('admin/winners/<uuid:student_id>', AdminDestroyWinnerView.as_view(), name='admin-destroy-winner'),
+    path('admin/winners/students/<uuid:student_id>', AdminDestroyWinnerView.as_view(), name='admin-destroy-winner'),
     path('admin/winners/talks/<int:talk_id>', AdminListCreateWinner.as_view(), name='admin-list-create-winner'),
 
     path('admin/students', include(admin_students_urls)),

--- a/src/services/api/urls.py
+++ b/src/services/api/urls.py
@@ -33,6 +33,7 @@ urlpatterns = [
     path('admin/gifts/<uuid:id>', AdminUpdateDestroyGiftView.as_view(), name='admin-update-destroy-gift'),
     path('admin/winners', AdminListWinnerView.as_view(), name='admin-list-draw-winners'),
     path('admin/winners/<uuid:student_id>', AdminDestroyWinnerView.as_view(), name='admin-destroy-winner'),
+    path('admin/winners/talks/<int:talk_id>', AdminListCreateWinner.as_view(), name='admin-list-create-winner'),
 
     path('admin/students', include(admin_students_urls)),
     path('admin/student', include(admin_student_urls)),

--- a/src/services/api/views.py
+++ b/src/services/api/views.py
@@ -1,22 +1,13 @@
-from datetime import datetime as dt, timedelta
-from zoneinfo import ZoneInfo
-
-from django.views.decorators.csrf import csrf_exempt
 from django.contrib.auth import authenticate, login, logout
-from django.db.models import F
-from django.http import Http404, JsonResponse
+from django.http import Http404
 from django.utils.decorators import method_decorator
-from rest_framework import generics, status
+from rest_framework import generics
 from rest_framework.decorators import api_view
-from rest_framework.response import Response
 from rest_framework.views import APIView
-from rest_framework_simplejwt.tokens import RefreshToken
 
 from .decorators import *
-from .models import *
 from .serializers import *
 from .utils import *
-from uuid import UUID
 
 
 ############################################################################################################

--- a/src/services/api/views.py
+++ b/src/services/api/views.py
@@ -388,7 +388,7 @@ class AdminDestroyWinnerView(generics.DestroyAPIView):
         return Response({'message': 'Vencedor removido com sucesso.'}, status=status.HTTP_200_OK)
 
 @method_decorator(admin_auth_required, name='dispatch')
-class AdminListCreateWinner(generics.ListAPIView):
+class AdminListCreateWinner(generics.ListCreateAPIView):
     serializer_class = DrawWinnerSerializer
     queryset = DrawWinner.objects.all()
 
@@ -401,3 +401,28 @@ class AdminListCreateWinner(generics.ListAPIView):
 
         draw_winners = DrawWinner.objects.filter(talk=talk_id).values('id', 'talk', 'student')
         return Response(list(draw_winners))
+
+    def post(self, request, *args, **kwargs):
+        talk_id = self.kwargs.get('talk_id')
+
+        talk = Talk.objects.filter(id=talk_id).first()
+        if not talk:
+            return Response({'error': f"Palestra com id {talk_id} não encontrada."}, status=status.HTTP_400_BAD_REQUEST)
+
+        student_id = request.data.get('student')
+        student = Student.objects.filter(id=student_id).first()
+        if not student:
+            return Response({'error': f"Alune com id {student_id} não encontrade."}, status=status.HTTP_400_BAD_REQUEST)
+
+        if not Presence.objects.filter(student=student_id, talk=talk_id).exists():
+            return Response({'error': 'Alune com presença não registrada nessa palestra.'}, status=status.HTTP_400_BAD_REQUEST)
+
+        if DrawWinner.objects.filter(student=student, talk=talk_id).exists():
+            return Response({'error': 'Alune já recebeu brinde nessa palestra.'}, status=status.HTTP_400_BAD_REQUEST)
+
+        draw_winner = DrawWinner.objects.create(talk=talk, student=student)
+        return Response({
+            'id': draw_winner.id,
+            'student': draw_winner.student_id,
+            'talk': draw_winner.talk_id,
+        }, status=status.HTTP_201_CREATED)

--- a/src/services/api/views.py
+++ b/src/services/api/views.py
@@ -386,3 +386,18 @@ class AdminDestroyWinnerView(generics.DestroyAPIView):
         obj.delete()
 
         return Response({'message': 'Vencedor removido com sucesso.'}, status=status.HTTP_200_OK)
+
+@method_decorator(admin_auth_required, name='dispatch')
+class AdminListCreateWinner(generics.ListAPIView):
+    serializer_class = DrawWinnerSerializer
+    queryset = DrawWinner.objects.all()
+
+    def get(self, request, *args, **kwargs):
+        talk_id = self.kwargs.get('talk_id')
+
+        talk = Talk.objects.filter(id=talk_id).first()
+        if not talk:
+            return Response({'error': f"Palestra com id {talk_id} não encontrada."}, status=status.HTTP_400_BAD_REQUEST)
+
+        draw_winners = DrawWinner.objects.filter(talk=talk_id).values('id', 'talk', 'student')
+        return Response(list(draw_winners))

--- a/tests/test_AdminListCreateWinner.py
+++ b/tests/test_AdminListCreateWinner.py
@@ -1,0 +1,176 @@
+from django.urls import reverse
+from rest_framework.test import APITestCase
+from rest_framework import status
+from django.contrib.auth.models import User
+from rest_framework.test import APIClient
+from api.models import Speaker, Student, Talk, Presence, DrawWinner
+from datetime import datetime as dt, timedelta
+from zoneinfo import ZoneInfo
+import uuid
+
+DATETIME_FORMAT = "%Y-%m-%dT%H:%M"
+
+class RetrieveSpeakerViewTestCase(APITestCase):
+    def setUp(self):
+        self.client = APIClient()
+        User.objects.create_superuser(
+            username='admin',
+            email='admin@test.com',
+            password='password123'
+        )
+        self.client.login(username='admin', password='password123')
+
+        # Cria modelos que serão utilizados em mais de uma funcao
+        self.student = Student.objects.create(
+            id=uuid.uuid4(),
+            name="Acabou a criatividade",
+            email="foi-mal-guys@usp.br",
+            usp_number="389245",
+            code="A004"
+        ) # Os estudantes abaixo sao mais legais
+
+        self.speaker = Speaker.objects.create(
+            id=uuid.uuid4(),
+            name="Maria Silva",
+            description="Especialista em IA",
+            social_media="@maria",
+            pronouns="ela/dela",
+            role="Junior frontend developer"
+        )
+
+        datetime_now = dt.now(ZoneInfo('America/Sao_Paulo'))
+        self.talk = Talk.objects.create(
+            id=1,
+            title='Introdução a Machine Learning',
+            speaker=self.speaker,
+            description='Aprenda o que é Machine Learning e quais técnicas aplicar em cada caso',
+            start_time=datetime_now.strftime(DATETIME_FORMAT),
+            end_time=(datetime_now + timedelta(hours=2)).strftime(DATETIME_FORMAT),
+        )
+
+        self.url = reverse('admin-list-create-winner', kwargs={'talk_id': self.talk.id})
+
+    def test_list_draw_winners(self):
+        student1 = Student.objects.create(
+            id=uuid.uuid4(),
+            name="CO-SSI da Silva Junior",
+            email="cossi.jr@usp.br",
+            usp_number="281905",
+            code="A001"
+        )
+
+        student2 = Student.objects.create(
+            id=uuid.uuid4(),
+            name="Luciano Digiampetri",
+            email="luciano.digi@usp.br",
+            usp_number="64023",
+            code="A002"
+        )
+
+        _presence1 = Presence.objects.create(
+            id=uuid.uuid4(),
+            student=student1,
+            talk=self.talk,
+        )
+
+        _presence2 = Presence.objects.create(
+            id=uuid.uuid4(),
+            student=student2,
+            talk=self.talk,
+        )
+
+        draw_winner1 = DrawWinner.objects.create(
+            id=uuid.uuid4(),
+            talk=self.talk,
+            student=student1,
+        )
+
+        draw_winner2 = DrawWinner.objects.create(
+            id=uuid.uuid4(),
+            talk=self.talk,
+            student=student2,
+        )
+
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 2)
+
+        draw_winner1 = {
+            "id": draw_winner1.id,
+            "student": draw_winner1.student.id,
+            "talk": draw_winner1.talk.id,
+        }
+
+        draw_winner2 = {
+            "id": draw_winner2.id,
+            "student": draw_winner2.student.id,
+            "talk": draw_winner2.talk.id,
+        }
+
+        self.assertDictEqual(draw_winner1, response.data[0])
+        self.assertDictEqual(draw_winner2, response.data[1])
+
+    def test_create_draw_winner(self):
+        student = Student.objects.create(
+            id=uuid.uuid4(),
+            name="José do Ensino Médio",
+            email="jem@usp.br",
+            usp_number="00000001",
+            code="A003"
+        )
+
+        _presence = Presence.objects.create(
+            id=uuid.uuid4(),
+            student=student,
+            talk=self.talk,
+        )
+
+        response = self.client.post(self.url, data={"student": student.id})
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+        self.assertEqual(student.id, response.data['student'])
+        self.assertEqual(self.talk.id, response.data['talk'])
+
+    def test_list_draw_winner_unauthorized(self):
+        self.client.logout()
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_list_draw_winner_invalid_talk(self):
+        url_with_invalid_talk = reverse('admin-list-create-winner', kwargs={'talk_id': 0})
+        response = self.client.get(url_with_invalid_talk)
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("error", response.data)
+
+    def test_create_draw_winner_unauthorized(self):
+        self.client.logout()
+        response = self.client.post(self.url)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_create_draw_winner_invalid_talk(self):
+        url_with_invalid_talk = reverse('admin-list-create-winner', kwargs={'talk_id': 0})
+        response = self.client.post(url_with_invalid_talk, data={"student": self.student.id})
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("error", response.data)
+
+    def test_create_draw_winner_invalid_student(self):
+        response = self.client.post(self.url, data={"student": uuid.uuid4()})
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("error", response.data)
+
+    def test_create_draw_winner_without_presence(self):
+        response = self.client.post(self.url, data={"student": self.student.id})
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("error", response.data)
+
+    def test_create_draw_winner_already_won(self):
+        response = self.client.post(self.url, data={"student": self.student.id})
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("error", response.data)


### PR DESCRIPTION
Surgiram algumas questões (a maioria já comentei com o Caio), uma delas é que hoje o código de views tem 3 ramos de padrão de código, um que utiliza Serializers para transformação, validação e tratamento de exceção, outro que utiliza Serializer apenas para transformação e validação e um último que basicamente não utiliza Serializer. Seria interessante no futuro padronizarmos isso (acho até que já criaram uma issue para isso).

Outra questão é que houve um conflito de rotas para `/admin/winners/<uuid:student_id>` feita pelo @mercuryVM e a que a tarefa pede (`/admin/winners/<uuid:talk_id>`), como elas são de recursos específicos diferentes (`student` e `talk`) eu separei elas, assim não tem mais conflito, mas no caso da rota da tarefa o correto mesmo seria utilizar uma rota `/admin/talks/<uuid:talk_id>/winners` pois estamos tratando os casos de criação e deleção dos `draw winners` de uma `talk` específica. No entanto não vejo problema algum manter como deixei no arquivo, talvez seja até menos confuso do que tentar ser purista. Só trouxe isso aqui porque precisei dar um refactor na rota do @mercuryVM (se puder validar depois também, agradeço muito :pray: )

Fecha #85