### PR TITLE
refactor(csrf): remove rota para token csrf

### DIFF
--- a/src/services/api/urls.py
+++ b/src/services/api/urls.py
@@ -15,7 +15,6 @@ register_converter(UUIDConverter, 'uuid')
 urlpatterns = [
     # Public endpoints
     path('', views.index, name='index'),
-    path('csrf', views.csrf, name='csrf'),
     path('admin/login', AdminLoginView.as_view(), name='admin-login'),
     path('admin/logout', AdminLogoutView.as_view(), name='admin-logout'),
 

--- a/src/services/api/views.py
+++ b/src/services/api/views.py
@@ -1,7 +1,5 @@
 
 from django.contrib.auth import authenticate, login, logout
-from django.http import JsonResponse
-from django.middleware.csrf import get_token
 from rest_framework import status
 from rest_framework.decorators import api_view
 from rest_framework.response import Response
@@ -27,18 +25,6 @@ from drf_spectacular.utils import extend_schema
 def index(request):
     """Ponto de entrada para o Saphira. Seja bem-vindo. Se essa endpoint não estiver funcionando o Saphira está fora do ar."""
     return Response({"message": "Bem-vinde à API Saphira!"}, status=status.HTTP_200_OK)
-
-@extend_schema(
-    tags=['Public'],
-    summary="Adquirir token CSRF",
-    responses={200: {"type": "object", "properties": {"csrfToken": {"type": "string"}}}}
-)
-@api_view(['GET'])
-def csrf(request):
-    """Rota apenas para retornar o token CSRF para frontend de cross-site origin. Deve ser chamada antes de qualquer outra requisição do fronted."""
-    return JsonResponse({
-        "csrfToken": get_token(request)
-    })
 
 @extend_schema(
     tags=['Admin'],


### PR DESCRIPTION
Agora o frontend utiliza reverse proxy para não ter problemas com cross-site, então o método de configurações anteriores não se fazem mais necessárias. Como a rota é pública e um GET simples o melhor é retirar ela, mesmo que não impacte na segurança, pois não será mais utilizada.