### PR TITLE
refactor(students): incluir paginação na rota de busca de students

### DIFF
--- a/src/services/students/pagination.py
+++ b/src/services/students/pagination.py
@@ -1,0 +1,15 @@
+from rest_framework.pagination import PageNumberPagination
+
+class StudentPagination(PageNumberPagination):
+    """Paginação das listagens de estudantes.
+
+    Parâmetros aceitos na URL:
+    - `page`: página desejada, começando em 1. Ex: /admin/students/?page=2
+    - `size`: quantidade de estudantes por página. Ex: /admin/students/?size=50
+
+    O tamanho padrão da página é 20 e o máximo permitido é 100.
+    """
+    page_size = 20
+    page_query_param = 'page'
+    page_size_query_param = 'size'
+    max_page_size = 100

--- a/src/services/students/serializers.py
+++ b/src/services/students/serializers.py
@@ -9,7 +9,8 @@ class StudentLoginSerializer(serializers.Serializer):
 class StudentSerializer(serializers.ModelSerializer):
     class Meta:
         model = Student
-        fields = ['id', 'name', 'email', 'usp_number']
+        fields = ['id', 'name', 'email', 'code', 'usp_number']
+        read_only_fields = ['code']  # gerado pelo sistema, nunca enviado pelo cliente
 
 class StudentGiftSerializer(serializers.ModelSerializer):
     student = StudentSerializer(read_only=True)

--- a/src/services/students/views.py
+++ b/src/services/students/views.py
@@ -16,6 +16,7 @@ from services.api.decorators import admin_auth_required, firebase_auth_required,
 from services.presences.models import Presence
 from .serializers import StudentSerializer, StudentGiftSerializer
 from .models import Student, StudentGift
+from .pagination import StudentPagination
 from .utils import apply_student_gift_filters
 
 
@@ -201,15 +202,18 @@ class ListRetrieveStudentGiftsView(generics.ListAPIView):
 @extend_schema(tags=["Students"], summary="List students")
 @method_decorator(admin_auth_required, name='dispatch')
 class AdminListStudentsView(generics.ListAPIView):
-    """Lista todos os estudantes"""
-    queryset = Student.objects.all()
+    """Lista todos os estudantes.
 
-    def list(self, request, *args, **kwargs):
-        queryset = self.get_queryset().values('id', 'email', 'name', 'code')
-        page = self.paginate_queryset(queryset)
-        if page is not None:
-            return self.get_paginated_response(page)
-        return Response(list(queryset))
+    A resposta é paginada e você pode controlá-la usando os seguintes parâmetros na URL:
+    - `page`: página desejada, começando em 1. Ex: /admin/students/?page=2
+    - `size`: quantidade de estudantes por página, no máximo 100. Ex: /admin/students/?size=50
+
+    O retorno segue o formato `{count, next, previous, results}`, onde `results` é a lista
+    de estudantes da página atual.
+    """
+    queryset = Student.objects.all().order_by('name', 'id')
+    serializer_class = StudentSerializer
+    pagination_class = StudentPagination
 
 @extend_schema(tags=["Students"], summary="Retrieve student by name")
 @method_decorator(admin_auth_required, name='dispatch')

--- a/tests/test_adminListStudentsView.py
+++ b/tests/test_adminListStudentsView.py
@@ -32,16 +32,33 @@ class AdminListStudentsViewTestCase(TestCase):
 
         self.url = reverse('admin-list-students')
 
+    def create_students(self, quantity, first_index=3):
+        """Cria estudantes extras, nomeados na mesma sequência dos criados no setUp"""
+        return Student.objects.bulk_create([
+            Student(
+                name=f'Aluno {index:02d}',
+                email=f'aluno{index:02d}@usp.br',
+                usp_number=f'{index:08d}',
+                code=f'B{index:03d}'
+            )
+            for index in range(first_index, first_index + quantity)
+        ])
+
     def test_list_students_authenticated(self):
         response = self.client.get(self.url)
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
-        self.assertEqual(len(response.data), 2)
+        self.assertEqual(response.data['count'], 2)
+        self.assertIsNone(response.data['next'])
+        self.assertIsNone(response.data['previous'])
 
-        returned_ids = [str(student['id']) for student in response.data]
-        returned_names = [student['name'] for student in response.data]
-        returned_codes = [student['code'] for student in response.data]
+        students = response.data['results']
+        self.assertEqual(len(students), 2)
+
+        returned_ids = [str(student['id']) for student in students]
+        returned_names = [student['name'] for student in students]
+        returned_codes = [student['code'] for student in students]
 
         self.assertIn(str(self.student1.id), returned_ids)
         self.assertIn(str(self.student2.id), returned_ids)
@@ -58,3 +75,71 @@ class AdminListStudentsViewTestCase(TestCase):
         response = self.client.get(self.url)
 
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_list_students_with_size(self):
+        self.create_students(3)  # 5 estudantes no total
+
+        response = self.client.get(self.url, {'size': 2})
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data['count'], 5)
+        self.assertEqual(len(response.data['results']), 2)
+        self.assertIsNotNone(response.data['next'])
+        self.assertIsNone(response.data['previous'])
+
+        # A lista é ordenada por nome, então a primeira página traz os dois primeiros alunos
+        self.assertEqual(
+            [student['name'] for student in response.data['results']],
+            ['Aluno 01', 'Aluno 02']
+        )
+
+    def test_list_students_with_page(self):
+        self.create_students(3)  # 5 estudantes no total
+
+        first_page = self.client.get(self.url, {'size': 2, 'page': 1})
+        second_page = self.client.get(self.url, {'size': 2, 'page': 2})
+
+        self.assertEqual(second_page.status_code, status.HTTP_200_OK)
+        self.assertEqual(second_page.data['count'], 5)
+        self.assertEqual(len(second_page.data['results']), 2)
+        self.assertIsNotNone(second_page.data['previous'])
+
+        self.assertEqual(
+            [student['name'] for student in second_page.data['results']],
+            ['Aluno 03', 'Aluno 04']
+        )
+
+        # Páginas diferentes não repetem estudantes
+        first_page_ids = {student['id'] for student in first_page.data['results']}
+        second_page_ids = {student['id'] for student in second_page.data['results']}
+        self.assertFalse(first_page_ids & second_page_ids)
+
+    def test_list_students_last_page(self):
+        self.create_students(3)  # 5 estudantes no total
+
+        response = self.client.get(self.url, {'size': 2, 'page': 3})
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data['results']), 1)
+        self.assertIsNone(response.data['next'])
+
+    def test_list_students_page_out_of_range(self):
+        response = self.client.get(self.url, {'size': 2, 'page': 99})
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_list_students_default_page_size(self):
+        self.create_students(30)  # 32 estudantes no total
+
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.data['count'], 32)
+        self.assertEqual(len(response.data['results']), 20)
+
+    def test_list_students_size_is_limited_to_max_page_size(self):
+        self.create_students(120)  # 122 estudantes no total
+
+        response = self.client.get(self.url, {'size': 500})
+
+        self.assertEqual(response.data['count'], 122)
+        self.assertEqual(len(response.data['results']), 100)


### PR DESCRIPTION
Lista todos os estudantes.

A resposta é paginada e você pode controlá-la usando os seguintes parâmetros na URL:
    - `page`: página desejada, começando em 1. Ex: /admin/students/?page=2
    - `size`: quantidade de estudantes por página, no máximo 100. Ex: /admin/students/?size=50

Closes #166 